### PR TITLE
Add desktop notifications for speech using python-notify2.

### DIFF
--- a/assistantdb.py
+++ b/assistantdb.py
@@ -1,14 +1,21 @@
 #!/usr/bin/python3
 
 import argparse
+import notify2
 import subprocess
 import sys
 import webbrowser
+
+notify2.init('LTU Assistant')
 
 def speak(message, also_cmd=False):
     '''Speak the given message using the text-to-speech backend.'''
     if also_cmd:
         print(message)
+    notification = notify2.Notification('LTU Assistant',
+                                        message,
+                                        'notification-message-im')
+    notification.show()
     subprocess.call('espeak "' + message + '"', shell=True)
 
 def process_website(site_name, verbose):
@@ -29,7 +36,7 @@ def process_website(site_name, verbose):
     elif site_name in ['calendar', 'schedule', 'events']:
         speak('Opening Google Calendar...', verbose)
         webbrowser.open('https://calendar.google.com')
-	# Khalil added this 
+	# Khalil added this
     elif site_name == 'weather':
         speak('Opening Google weather...', verbose)
         webbrowser.open('http://www.weather.com/weather/today/l/USMI0283:1:US')
@@ -84,7 +91,7 @@ def process_find_room(room_str, verbose):
     speak(finder_message, verbose)
 
 def parse(verb, verb_object, alternate_verb, alternate_noun, verbose=False):
-    browse_cmd_list = ['start', 'open', 'go', 'go to', 'browse', 'browse to', 'launch', 'take to', 'show'] #Original verb only + addition verb 'show' 
+    browse_cmd_list = ['start', 'open', 'go', 'go to', 'browse', 'browse to', 'launch', 'take to', 'show'] #Original verb only + addition verb 'show'
     email_cmd_list = ['email', 'compose', 'send']
     roomfinder_cmd_list = ['find', 'where is']
 

--- a/setup.sh
+++ b/setup.sh
@@ -18,7 +18,7 @@ fi
 
 printf "\033[1;31mInstalling libraries, this requires root (please enter your password)\033[m\n\n"
 printf "\033[1;34mInstalling apt-get libraries\033[m\n\n"
-sudo apt-get install python python-pip python-pyaudio espeak flac default-jre
+sudo apt-get install python python-notify2 python-pip python-pyaudio espeak flac default-jre
 printf "\033[1;34mInstalling Speech Recognition library via pip\033[m\n\n"
 sudo pip install SpeechRecognition
 printf "\033[1;34mInstalling CoreNLP wrapper\033[m\n\n"


### PR DESCRIPTION
This pulls in an additional Python package (`python-notify2`) to display NotifyOSD desktop notifications along with the speech output for the assistant's response. Please review and merge if ready.

Note that to configure your system to use the new notifications, all that should be required is running

```
sudo apt-get install python-notify2
```

in a terminal as opposed to running `setup.sh` again (though it is added to the package list there too).
